### PR TITLE
Improve buildSbtProgram diagnostics for library projects

### DIFF
--- a/plugin/nix-exprs/sbtix.nix
+++ b/plugin/nix-exprs/sbtix.nix
@@ -381,7 +381,13 @@ in rec {
             chmod -R u+w ./.sbt-boot || true
           fi
           export SBT_OPTS="''${SBT_OPTS:-} -Duser.home=$localHome"
-          HOME="$localHome" XDG_CACHE_HOME="$localCache" sbt stage
+          if ! HOME="$localHome" XDG_CACHE_HOME="$localCache" sbt stage; then
+            echo "error: buildSbtProgram could not run sbt stage." 1>&2
+            echo "expected: sbt stage creates target/universal/stage, usually via sbt-native-packager." 1>&2
+            echo "if this project is a library, use sbtix.buildSbtLibrary instead." 1>&2
+            echo "for custom layouts, use sbtix.buildSbtProject with an installPhase." 1>&2
+            exit 1
+          fi
           mkdir -p $out/
           copied_any=0
           copy_stage_root() {
@@ -401,7 +407,10 @@ in rec {
           done < <(find . -path '*/target/universal/stage' -type d)
 
           if [ $copied_any -eq 0 ]; then
-            echo "error: no staged artifacts found. Ensure sbt-native-packager is enabled or override sbtix.buildSbtProgram." 1>&2
+            echo "error: buildSbtProgram did not find staged application output." 1>&2
+            echo "expected: sbt stage creates target/universal/stage, usually via sbt-native-packager." 1>&2
+            echo "if this project is a library, use sbtix.buildSbtLibrary instead." 1>&2
+            echo "for custom layouts, use sbtix.buildSbtProject with an installPhase." 1>&2
             exit 1
           fi
           for p in $(find $out/bin/* -executable); do

--- a/plugin/src/sbt-test/sbtix/library-diagnostic/Main.scala
+++ b/plugin/src/sbt-test/sbtix/library-diagnostic/Main.scala
@@ -1,0 +1,3 @@
+object Main {
+  val message: String = "library"
+}

--- a/plugin/src/sbt-test/sbtix/library-diagnostic/build.sbt
+++ b/plugin/src/sbt-test/sbtix/library-diagnostic/build.sbt
@@ -1,0 +1,3 @@
+name := "library-diagnostic"
+version := "0.1.0"
+scalaVersion := "2.13.16"

--- a/plugin/src/sbt-test/sbtix/library-diagnostic/default.nix
+++ b/plugin/src/sbt-test/sbtix/library-diagnostic/default.nix
@@ -1,0 +1,24 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  fakeSbt = pkgs.writeShellScriptBin "sbt" ''
+    echo "fake sbt: $*" 1>&2
+    if [ "''${1:-}" = "stage" ]; then
+      exit 1
+    fi
+    exit 0
+  '';
+
+  sbtix = pkgs.callPackage ./sbtix.nix {
+    sbt = fakeSbt;
+  };
+in
+  sbtix.buildSbtProgram {
+    name = "library-diagnostic";
+    src = ./.;
+    repo = [];
+    buildPhase = ''
+      runHook preBuild
+      runHook postBuild
+    '';
+  }

--- a/plugin/src/sbt-test/sbtix/library-diagnostic/project/build.properties
+++ b/plugin/src/sbt-test/sbtix/library-diagnostic/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.10.7

--- a/plugin/src/sbt-test/sbtix/library-diagnostic/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbtix/library-diagnostic/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(version) => addSbtPlugin("se.nullable.sbtix" % "sbtix" % version)
+  case _ => sys.error("The system property 'plugin.version' is not defined.")
+}

--- a/plugin/src/sbt-test/sbtix/library-diagnostic/test
+++ b/plugin/src/sbt-test/sbtix/library-diagnostic/test
@@ -1,0 +1,5 @@
+# Verify that buildSbtProgram gives an actionable error for library-style projects.
+> genComposition
+$ exists default.nix
+$ exists sbtix.nix
+$ exec sh -c 'rm -rf result nix-build.log; if nix-build > nix-build.log 2>&1; then cat nix-build.log; exit 1; fi; grep -q "error: buildSbtProgram could not run sbt stage." nix-build.log && grep -q "if this project is a library, use sbtix.buildSbtLibrary instead." nix-build.log && grep -q "for custom layouts, use sbtix.buildSbtProject with an installPhase." nix-build.log || { cat nix-build.log; exit 1; }'


### PR DESCRIPTION
## Summary

- Add actionable error output when `buildSbtProgram` cannot run `sbt stage`
- Expand the existing missing-stage-output diagnostic with guidance for library projects and custom layouts
- Add a scripted regression test covering the library-style failure case

## Verification

- `nix develop .. --command sbt test`
- `nix develop .. --command sbt "scripted sbtix/library-diagnostic"`
- `nix develop .. --command sbt "scripted sbtix/simple"`
- `nix develop . --command ... sbt "scripted sbtix/private-auth"`
- `nix build '.#sbtix'`
- `nix develop . --command ... ./tests/multi-build/run.sh; ./tests/template-generation/run.sh`
- `nix-instantiate --parse plugin/nix-exprs/sbtix.nix`
- `git diff --check`
- `git diff --cached --check`