### PR TITLE
Avoid locking javadoc artifacts by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ in
 By default, sbtix keeps verbose resolver diagnostics off for performance. To enable
 the full `[SBTIX_DEBUG]` output, set `SBTIX_DEBUG=1` (or pass `-Dsbtix.debug=true`).
 
+By default, generated locks include main artifacts plus the `tests` and `sources`
+classifier artifacts, and skip `javadoc` jars to avoid extra downloads. To include
+javadocs, add this to your sbt build:
+
+```scala
+sbtixArtifactClassifiers += "javadoc"
+```
+
+Set `sbtixArtifactClassifiers := Seq.empty` if you only want main artifacts.
+
 #### Typical regeneration flow
 
 1. `sbtix-gen-all2` – regenerates every `repo.nix` layer (`repo.nix`, `project/repo.nix`, `project/project/repo.nix`) **and runs `genComposition`** to render `sbtix-generated.nix`. Check these files into VCS so CI and teammates get the same locks.

--- a/plugin/src/main/scala/se/nullable/sbtix/CoursierArtifactFetcher.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/CoursierArtifactFetcher.scala
@@ -95,7 +95,8 @@ class CoursierArtifactFetcher(
   credentials: Set[Credentials],
   scalaVersion: String,
   scalaBinaryVersion: String,
-  extraIvyProps: Map[String, String] = Map.empty
+  extraIvyProps: Map[String, String] = Map.empty,
+  artifactClassifiers: Seq[String] = Seq("tests", "sources")
 ) {
 
   private val metaArtifactCollector = new ConcurrentSkipListSet[MetaArtifact]()
@@ -335,7 +336,11 @@ class CoursierArtifactFetcher(
 
       val mainArtifacts = resolution.dependencyArtifacts().toSet
       val classifierArtifacts =
-        resolution.dependencyArtifacts(classifiers = Some(Seq("tests", "sources", "javadoc").map(Classifier(_)))).toSet
+        artifactClassifiers.distinct match {
+          case Nil => Set.empty[(CDependency, Publication, CArtifact)]
+          case classifiers =>
+            resolution.dependencyArtifacts(classifiers = Some(classifiers.map(Classifier(_)))).toSet
+        }
 
       val artifacts =
         mainArtifacts

--- a/plugin/src/main/scala/se/nullable/sbtix/SbtixPlugin.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/SbtixPlugin.scala
@@ -308,6 +308,7 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
     
     val sbtixNixFile = settingKey[File]("The Nix file to generate")
     val sbtixRepository = settingKey[String]("URL of the repository to use")
+    val sbtixArtifactClassifiers = settingKey[Seq[String]]("Artifact classifiers to lock in addition to main artifacts")
     
     // Setting to customize the default.nix content
     val sbtixNixContentTemplate = settingKey[(String, String, String, String) => String]("Function to generate Nix file content")
@@ -470,6 +471,8 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
     sbtixNixFile := new File(baseDirectory.value, "sbtix.nix"),
     
     sbtixRepository := "https://repo1.maven.org/maven2",
+
+    sbtixArtifactClassifiers := Seq("tests", "sources"),
     
     // Setting the default template for generated Nix content
     sbtixNixContentTemplate := generatedNixContentTemplate _,
@@ -499,7 +502,8 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
         projectResolvers,
         fetchedCredentials,
         scalaVer,
-        scalaBinaryVersion.value
+        scalaBinaryVersion.value,
+        artifactClassifiers = sbtixArtifactClassifiers.value
       )
       val (repos, artifacts, provided, errors) = fetcher(dependencies)
       logProvidedArtifacts(log, "sbtixBuildInputs", provided)
@@ -546,7 +550,8 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
         projectResolvers,
         projectCredentials,
         scalaVer,
-        scalaBinaryVersion.value
+        scalaBinaryVersion.value,
+        artifactClassifiers = sbtixArtifactClassifiers.value
       )
 
       val (repos, artifacts, provided, errors) = fetcher(dependencies)
@@ -599,7 +604,8 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
               "scalaBinaryVersion" -> scalaBinaryVersion.value,
               "sbtVersion" -> sbtBinaryVersion.value,
               "sbtBinaryVersion" -> sbtBinaryVersion.value
-            )
+            ),
+            artifactClassifiers = sbtixArtifactClassifiers.value
           )
           val pluginDependencies = pluginModuleIds.map(Dependency(_))
           val (pluginRepos, pluginArtifacts, pluginProvided, pluginErrors) =
@@ -1006,4 +1012,4 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
   )
 }
 
-// NixWriter isn't needed anymore as BuildInputs has toNix method 
+// NixWriter isn't needed anymore as BuildInputs has toNix method

--- a/plugin/src/test/scala/sbtix/CoursierArtifactFetcherSpec.scala
+++ b/plugin/src/test/scala/sbtix/CoursierArtifactFetcherSpec.scala
@@ -55,13 +55,14 @@ class CoursierArtifactFetcherSpec extends AnyFlatSpec with Matchers {
     )
     
     // Call the fetcher
-        val (repos, artifacts, provided, errors) = fetcher(dependencies)
+    val (repos, artifacts, provided, errors) = fetcher(dependencies)
     
     // Verify the results
     repos should not be empty
     artifacts should not be empty
-        errors.flatMap(_.errors) shouldBe empty
-        provided shouldBe empty
+    errors.flatMap(_.errors) shouldBe empty
+    provided shouldBe empty
+    artifacts.exists(_.relativePath.contains("-javadoc.jar")) shouldBe false
     
     // Print some debug info
     println(s"Repositories: ${repos.size}")
@@ -69,6 +70,33 @@ class CoursierArtifactFetcherSpec extends AnyFlatSpec with Matchers {
     artifacts.take(3).foreach { a =>
       println(s"Artifact: ${a.repoName}/${a.relativePath} - ${a.sha256}")
     }
+  }
+
+  it should "include javadoc classifier artifacts when configured" in {
+    val resolvers = Set[Resolver](
+      MavenRepository("central", "https://repo1.maven.org/maven2")
+    )
+
+    val dependencies = Set(
+      Dependency(
+        ModuleID("com.typesafe", "config", "1.4.2")
+      )
+    )
+
+    val fetcher = new CoursierArtifactFetcher(
+      mockLogger,
+      resolvers,
+      Set.empty,
+      "2.12.20",
+      "2.12",
+      artifactClassifiers = Seq("javadoc")
+    )
+
+    val (_, artifacts, provided, errors) = fetcher(dependencies)
+
+    errors.flatMap(_.errors) shouldBe empty
+    provided shouldBe empty
+    artifacts.exists(_.relativePath.contains("-javadoc.jar")) shouldBe true
   }
 
   it should "preserve Ivy resolver patterns for sbt plugin repositories" in {


### PR DESCRIPTION
## Summary

- Add `sbtixArtifactClassifiers` to control which classifier artifacts sbtix locks.
- Default classifier locking to `tests` and `sources`, skipping `javadoc` jars by default.
- Document how to opt back into javadoc locking with `sbtixArtifactClassifiers += "javadoc"`.

## Testing

- `nix develop . --command bash -lc 'cd plugin && sbt test'`
- `nix build .#sbtix -L`
- `nix develop . --command ./tests/multi-build/run.sh`
- `nix develop . --command ./tests/template-generation/run.sh`
- `nix develop . --command bash -lc 'cd plugin && sbt "scripted sbtix/simple" "scripted sbtix/library-diagnostic"'`
- `nix develop . --command bash -lc 'python3 serve-authenticated.py & server=$!; sleep 1; if ! kill -0 "$server" 2>/dev/null; then echo "auth server failed to start" >&2; wait "$server"; exit 1; fi; trap "kill $server 2>/dev/null || true" EXIT INT TERM; cd plugin; sbt "scripted sbtix/private-auth"'`
- `nix flake check -L`

Note: `nix flake check -L --all-systems` could not run locally because this aarch64-darwin machine has no `x86_64-linux` builder.