### PR TITLE
Prepare sbtix 1.0.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
             sbt "scripted sbtix/private-auth"
           '
 
+      - name: Run scripted scalafmt test
+        run: nix develop . --command bash -lc 'cd plugin && sbt "scripted sbtix/scalafmt"'
+
+      - name: Run scripted Scala 3 test
+        run: nix develop . --command bash -lc 'cd plugin && sbt "scripted sbtix/scala3"'
+
   nix:
     name: Nix build and integration (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 1.0.0
+
+Sbtix 1.0.0 is the stable baseline for generating locked Nix repositories for sbt builds and building those projects offline in the Nix sandbox.
+
+### Highlights
+
+- Generate `sbtix-generated.nix` compositions that keep downstream flake evaluation pure when sbtix is used from a pinned flake input.
+- Build and test the project on GitHub Actions for both x86_64 Linux and ARM Linux.
+- Improve `buildSbtProgram` diagnostics when a project is actually a library or does not provide a `stage` task.
+- Skip javadoc classifier artifacts by default while keeping `sbtixArtifactClassifiers` available for opt-in classifier locking.
+- Support offline sbt-scalafmt builds by locking the configured formatter runtime and relevant plugin artifacts.
+- Lock Scala 2.13 and Scala 3 sbt compiler bridge artifacts for sandboxed builds.
+- Keep generated `default.nix` handling non-destructive: existing files are left untouched.
+
+### Notes
+
+- `sbtix-gen-all` remains for compatibility and runs `genNix`; `sbtix-gen-all2` is the recommended full regeneration command because it also runs `genComposition`.
+- Projects using sbt plugins that download tooling at runtime may still need to disable those tasks under `SBTIX_NIX_BUILD=1` or add rare missing artifacts to `manual-repo.nix`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ When you touch the templates under `plugin/src/main/resources/sbtix/` (for examp
 
 ```bash
 # NOTE: Keep `plugin.version` in sync with `plugin/build.sbt` (`version := ...`).
-(cd plugin/src/sbt-test/sbtix/simple && sbt --error -Dplugin.version=0.5.0 "clean" "genNix" "genComposition")
+(cd plugin/src/sbt-test/sbtix/simple && sbt --error -Dplugin.version=1.0.0 "clean" "genNix" "genComposition")
 ```
 
 The scripted tests only check in and assert on the locked `repo.nix` files (`expected/repo.nix` and `expected/project-repo.nix`).  

--- a/README.md
+++ b/README.md
@@ -27,12 +27,23 @@ This pipeline keeps your sbt workflow fast (dependency metadata is cached) while
 
 ## Why not? (caveats)
 
-* Pre-1.0 / beta: used in production, but expect occasional breaking changes while the API and Nix/SBT integration stabilizes. Please report any issues!
+* Sbtix 1.0.0 is intended as the stable baseline for the current CLI, generated Nix, and builder APIs. Please report any regressions or missing offline artifacts.
 * Some sbt-internal tooling artifacts are not declared as normal project/library dependencies. sbtix locks the Scala 2.13 / Scala 3 compiler bridge (`org.scala-lang:scala2-sbt-bridge` / `org.scala-lang:scala3-sbt-bridge`) automatically, but you may still need to add rare missing artifacts to `manual-repo.nix`.
 * sbtix detects `sbt-scalafmt` in `project/plugins.sbt` and locks the configured `.scalafmt.conf` formatter runtime automatically, so `scalafmtOnCompile` can run in sandboxed Nix builds. For other plugins that download tooling at runtime, either disable non-build tasks when `SBTIX_NIX_BUILD=1` / `-Dsbtix.nixBuild=true` is set, or add the missing artifacts to `manual-repo.nix`.
 * **Offline sbt bootstrap is pinned:** the generated `sbtix-plugin-repo.nix` (seeded from sbtix’s bundled template under `plugin/sbtix-plugin-repo.nix`) only includes sbt launcher/bootstrap artifacts for the sbt version shipped with sbtix (currently sbt `1.10.7`, e.g. `org.scala-sbt:main_2.12:1.10.7`). If your project uses a different `sbt.version` in `project/build.properties`, a sandboxed/offline `nix build` can fail unless those sbt boot artifacts are also available offline (typically by aligning `sbt.version`, or by manually pinning the missing sbt artifacts in `manual-repo.nix`).
 
 ## How?
+
+Sbtix is intended to be used as a Nix-provided command-line tool. The tool
+loads a matching sbt plugin into a separate sbt global base while it generates
+`repo.nix` and `sbtix-generated.nix`. In normal projects, you should not add
+sbtix to `project/plugins.sbt` yourself; using the Nix CLI keeps the plugin jar,
+Nix builders, templates, and generated source pin on the same sbtix version or
+commit.
+
+Direct sbt-plugin use is mainly for sbtix development or custom internal
+workflows where you deliberately publish/provide the plugin artifact yourself
+and take responsibility for keeping it in sync with the Nix expressions.
 
 To install sbtix either:
 
@@ -62,7 +73,7 @@ Add an input and expose the sbtix CLI in your dev shell:
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # Prefer a tag (or pinned commit) so the sbtix input is stable.
-    sbtix.url = "github:natural-transformation/sbtix/v0.5.0";
+    sbtix.url = "github:natural-transformation/sbtix/v1.0.0";
 
     # Optional: keep nixpkgs consistent across inputs.
     sbtix.inputs.nixpkgs.follows = "nixpkgs";
@@ -136,7 +147,15 @@ Set `sbtixArtifactClassifiers := Seq.empty` if you only want main artifacts.
 * run `sbtix genComposition` (or `sbt genComposition` inside your project) to have sbtix emit `sbtix-generated.nix` for you. The file is rendered from the same template used in our tests, so it already contains the sandbox-friendly `SBT_OPTS`, Ivy generation, and install logic. Check it in as-is and have your `default.nix` (or another entry point) simply import it.
 * if you do need to hand-roll the derivation, the snippet below shows how to call `sbtix.buildSbtProgram` directly. (Use `buildSbtLibrary` if you are packaging a library or `buildSbtProject` for a custom `installPhase`.) You can keep your custom logic in `default.nix` while still generating `sbtix-generated.nix` for reference.
 
-If you want a starting point, copy `default.nix.example` from this repository into your project and adapt it. The root-level `default.nix` now just raises an error so it no longer looks like part of the build.
+If you want a starting point, copy `default.nix.example` from this repository into your project. It simply imports the generated composition:
+
+```nix
+{ pkgs ? import <nixpkgs> {} }:
+
+import ./sbtix-generated.nix { inherit pkgs; }
+```
+
+The root-level `default.nix` now just raises an error so it no longer looks like part of the build. If you need to hand-roll the derivation instead, use the lower-level API directly:
 
 ```nix
 { pkgs ? import <nixpkgs> {} }: with pkgs;
@@ -162,8 +181,8 @@ in
 * generate your repo.nix files with one of the commands listed above. `sbtix-gen-all2` is recommended.
 * rerun `sbtix genComposition` after changing dependencies to regenerate `sbtix-generated.nix` so it stays in sync with both the template and the sbtix revision you are using.
 * check the generated nix files (including `sbtix-generated.nix`) into your source control.
- * finally, run `nix-build` to build!
- * any additional missing dependencies that `nix-build` encounters should be fetched with `nix-prefetch-url` and added to `manual-repo.nix`.
+* finally, run `nix-build` to build!
+* any additional missing dependencies that `nix-build` encounters should be fetched with `nix-prefetch-url` and added to `manual-repo.nix`.
 
 #### Keeping nix files separate from the project sources
 
@@ -272,30 +291,30 @@ A: You probably need to add the following resolver to your project for Sbtix to 
 
 ```scala
 // if using PlayFramework
-resolvers += Resolver.url("sbt-plugins-releases", url("https://dl.bintray.com/playframework/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.url(
+  "sbt-plugin-releases",
+  url("https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/")
+)(Resolver.ivyStylePatterns)
 ```
 
 Q: When I `nix-build` it sbt complains `java.io.IOException: Cannot run program "git": error=2, No such file or directory`
 
-A: You are likely depending on a project via git.  This isn't recommended usage for sbtix since it leads to non-deterministic builds. However you can enable this by making two small changes to sbtix.nix, in order to make git a buildInput.
+A: You are likely depending on a project via git. This is not recommended because it can make builds non-deterministic. Prefer replacing the git dependency with a pinned source dependency or a normal repository artifact. If your build really needs to shell out to git, pass it as a build input in your Nix expression:
 
-top of sbtix.nix with git as buildinput
 ```nix
-{ runCommand, fetchurl, lib, stdenv, jdk, sbt, writeText, git }:
+sbtix.buildSbtProgram {
+  # ...
+  buildInputs = [ pkgs.git ];
+}
 ```
 
-bottom of sbtix.nix with git as buildinput
-```nix
-buildInputs = [ jdk sbt git ] ++ buildInputs;
-```
+Q: How do I keep my own `default.nix`?
 
-Q: How do I disable the generation of a `default.nix`?
-
-A: You have to add `generateComposition := false` to your `build.sbt`.
+A: Keep your own `default.nix` in the project. `genComposition` writes `sbtix-generated.nix` every time, but it only writes an example `default.nix` when one does not already exist.
 
 Q: How do I use a different type of SBT build in `default.nix`
 
-A: You can change the value of `compositionType` in your `build.sbt`. Allowed values are `program` and `library`. In the end the `sbtix.buildSbt{compositionType}` API in the nix expressions will be used.
+A: The generated composition uses `sbtix.buildSbtProgram`, which expects a `stage` task. For libraries, call `sbtix.buildSbtLibrary` directly from your own `default.nix`; for custom layouts, call `sbtix.buildSbtProject` with an explicit `installPhase`.
 
 ## Thanks
 

--- a/default.nix.example
+++ b/default.nix.example
@@ -1,38 +1,3 @@
 { pkgs ? import <nixpkgs> {} }:
 
-let
-  sbtixRepo = if builtins.pathExists ./repo.nix
-              then import ./repo.nix {
-                inherit (pkgs) fetchurl fetchgit fetchzip;
-              }
-              else { repos = []; };
-
-  sbtWithRepo = pkgs.sbt.override {
-    jre = pkgs.jdk11;
-  };
-
-in pkgs.stdenv.mkDerivation {
-  name = "sbtix-project";
-  src = ./.;
-
-  buildInputs = [ sbtWithRepo pkgs.jdk11 ];
-
-  shellHook = ''
-    export SBT_OPTS="${builtins.concatStringsSep " " (map (repoPath: "-Dsbt.repository.config=" + repoPath + "/repositories") sbtixRepo.repos)}"
-    if [ -n "$SBT_OPTS" ]; then
-      echo "SBT_OPTS set to: $SBT_OPTS"
-    else
-      echo "Warning: ./repo.nix not found or did not define any repos. SBT_OPTS is empty."
-    fi
-  '';
-
-  buildPhase = ''
-    sbt compile
-  '';
-
-  installPhase = ''
-    mkdir -p $out
-    cp -r target $out/
-  '';
-}
-
+import ./sbtix-generated.nix { inherit pkgs; }

--- a/plugin/build.sbt
+++ b/plugin/build.sbt
@@ -2,7 +2,7 @@ sbtPlugin := true
 
 name         := "sbtix"
 organization := "se.nullable.sbtix"
-version      := "0.5.0"
+version      := "1.0.0"
 
 publishTo := {
     if (isSnapshot.value) {
@@ -14,12 +14,12 @@ publishTo := {
 
 
 licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
-homepage := Some(url("https://gitlab.com/teozkr/Sbtix"))
+homepage := Some(url("https://github.com/natural-transformation/sbtix"))
 
 scmInfo := Some(
   ScmInfo(
-    url("https://gitlab.com/teozkr/sbtix"),
-    "scm:git@gitlab.com:teozkr/sbtix.git"
+    url("https://github.com/natural-transformation/sbtix"),
+    "scm:git:https://github.com/natural-transformation/sbtix.git"
   )
 )
 

--- a/plugin/src/main/scala/se/nullable/sbtix/NixPlugin.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/NixPlugin.scala
@@ -27,7 +27,7 @@ object NixPlugin extends AutoPlugin {
     sbtixNixFile := new File(baseDirectory.value, "sbtix.nix"),
     nixRepoFile := new File(baseDirectory.value, "repo.nix"),
     nixProjectRepo := new File(new File(baseDirectory.value, "project"), "repo.nix"),
-    sbtixVersion := "0.3-SNAPSHOT"
+    sbtixVersion := "1.0.0"
   )
 
   override def globalSettings = Seq(

--- a/plugin/src/sbt-test/sbtix/scala3/Main.scala
+++ b/plugin/src/sbt-test/sbtix/scala3/Main.scala
@@ -1,0 +1,2 @@
+@main def main(): Unit =
+  println("hello scala3")

--- a/plugin/src/sbt-test/sbtix/scala3/build.sbt
+++ b/plugin/src/sbt-test/sbtix/scala3/build.sbt
@@ -1,0 +1,20 @@
+ThisBuild / scalaVersion := "3.3.4"
+ThisBuild / version := "0.1.0"
+
+lazy val stage = taskKey[File]("Stage a minimal executable for sbtix buildSbtProgram")
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "scala3-test",
+    stage := {
+      (Compile / compile).value
+      val stageDir = target.value / "universal" / "stage"
+      val binDir = stageDir / "bin"
+      IO.delete(stageDir)
+      IO.createDirectory(binDir)
+      val executable = binDir / "scala3-fixture"
+      IO.write(executable, "#!/usr/bin/env sh\necho hello scala3\n")
+      executable.setExecutable(true)
+      stageDir
+    }
+  )

--- a/plugin/src/sbt-test/sbtix/scala3/default.nix
+++ b/plugin/src/sbt-test/sbtix/scala3/default.nix
@@ -1,0 +1,4 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  sbtixGenerated = import ./sbtix-generated.nix { inherit pkgs; };
+in sbtixGenerated

--- a/plugin/src/sbt-test/sbtix/scala3/project/build.properties
+++ b/plugin/src/sbt-test/sbtix/scala3/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.10.7

--- a/plugin/src/sbt-test/sbtix/scala3/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbtix/scala3/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(version) => addSbtPlugin("se.nullable.sbtix" % "sbtix" % version)
+  case _ => sys.error("The system property 'plugin.version' is not defined.")
+}

--- a/plugin/src/sbt-test/sbtix/scala3/test
+++ b/plugin/src/sbt-test/sbtix/scala3/test
@@ -1,0 +1,10 @@
+> compile
+> genNix
+$ exists repo.nix
+$ exists project/repo.nix
+$ exec grep -q 'org/scala-lang/scala3-sbt-bridge/3.3.4/scala3-sbt-bridge-3.3.4.jar' repo.nix
+> genComposition
+$ exists default.nix
+$ exec rm -rf result
+$ exec nix-build
+$ exec result/bin/scala3-fixture

--- a/sbtix-tool.nix
+++ b/sbtix-tool.nix
@@ -2,7 +2,7 @@
 , jdk, jre, sbt, selfSourceInfo ? {}
 }:
 let
-  version = "0.5.0";
+  version = "1.0.0";
   versionSnapshotSuffix = "";
   pluginVersion = "${version}${versionSnapshotSuffix}";
 


### PR DESCRIPTION
## Summary

Prepare sbtix for the 1.0.0 release by updating release metadata, clarifying the intended Nix-first user workflow, and tightening CI coverage for headline 1.0 features.

## Changes

- Bump sbtix version metadata to `1.0.0`
- Add `CHANGELOG.md` for the 1.0.0 release
- Update README examples, caveats, FAQ, and flake pin to `v1.0.0`
- Clarify that users should normally consume sbtix via the Nix-provided CLI, not by manually adding the sbt plugin
- Simplify `default.nix.example` to import `sbtix-generated.nix`
- Update project homepage/scm metadata to GitHub
- Add CI coverage for:
  - `scripted sbtix/scalafmt`
  - `scripted sbtix/scala3`
- Add a Scala 3 scripted fixture that verifies `scala3-sbt-bridge` locking and a generated offline Nix build

## Verification

- `nix build .#sbtix -L`
- `nix develop . --command ./tests/multi-build/run.sh`
- `nix develop . --command ./tests/template-generation/run.sh`
- `nix develop . --command bash -lc 'cd plugin && sbt test'`
- `nix develop . --command bash -lc 'cd plugin && sbt "scripted sbtix/library-diagnostic" "scripted sbtix/simple" "scripted sbtix/scalafmt"'`
- `nix develop . --command bash -lc 'cd plugin && sbt "scripted sbtix/scala3"'`
- private-auth scripted test with local auth server
- `nix flake check -L`
- `git diff --check`
- `git diff --cached --check`