### PR TITLE
Skip mutable Maven metadata in repo locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.1 (unreleased)
+
+### Fixed
+
+- Do not pin mutable Maven `maven-metadata.xml` files in generated `repo.nix` locks when Coursier fetches them while resolving version ranges or repository metadata. This keeps generated Nix repositories reproducible after regenerating locks.
+
 ## 1.0.0
 
 Sbtix 1.0.0 is the stable baseline for generating locked Nix repositories for sbt builds and building those projects offline in the Nix sandbox.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Do not pin mutable Maven `maven-metadata.xml` files in generated `repo.nix` locks when Coursier fetches them while resolving version ranges or repository metadata. This keeps generated Nix repositories reproducible after regenerating locks.
+- Do not pin mutable Maven `maven-metadata.xml` files or sidecars in generated `repo.nix` locks when Coursier fetches them while resolving version ranges or repository metadata. This keeps generated Nix repositories reproducible after regenerating locks.
 
 ## 1.0.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ When you touch the templates under `plugin/src/main/resources/sbtix/` (for examp
 
 ```bash
 # NOTE: Keep `plugin.version` in sync with `plugin/build.sbt` (`version := ...`).
-(cd plugin/src/sbt-test/sbtix/simple && sbt --error -Dplugin.version=1.0.0 "clean" "genNix" "genComposition")
+(cd plugin/src/sbt-test/sbtix/simple && sbt --error -Dplugin.version=1.0.1 "clean" "genNix" "genComposition")
 ```
 
 The scripted tests only check in and assert on the locked `repo.nix` files (`expected/repo.nix` and `expected/project-repo.nix`).  

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This pipeline keeps your sbt workflow fast (dependency metadata is cached) while
 
 ## Why not? (caveats)
 
-* Sbtix 1.0.0 is intended as the stable baseline for the current CLI, generated Nix, and builder APIs. Please report any regressions or missing offline artifacts.
+* Sbtix 1.0.x is intended as the stable baseline for the current CLI, generated Nix, and builder APIs. Please report any regressions or missing offline artifacts.
 * Some sbt-internal tooling artifacts are not declared as normal project/library dependencies. sbtix locks the Scala 2.13 / Scala 3 compiler bridge (`org.scala-lang:scala2-sbt-bridge` / `org.scala-lang:scala3-sbt-bridge`) automatically, but you may still need to add rare missing artifacts to `manual-repo.nix`.
 * sbtix detects `sbt-scalafmt` in `project/plugins.sbt` and locks the configured `.scalafmt.conf` formatter runtime automatically, so `scalafmtOnCompile` can run in sandboxed Nix builds. For other plugins that download tooling at runtime, either disable non-build tasks when `SBTIX_NIX_BUILD=1` / `-Dsbtix.nixBuild=true` is set, or add the missing artifacts to `manual-repo.nix`.
 * **Offline sbt bootstrap is pinned:** the generated `sbtix-plugin-repo.nix` (seeded from sbtix’s bundled template under `plugin/sbtix-plugin-repo.nix`) only includes sbt launcher/bootstrap artifacts for the sbt version shipped with sbtix (currently sbt `1.10.7`, e.g. `org.scala-sbt:main_2.12:1.10.7`). If your project uses a different `sbt.version` in `project/build.properties`, a sandboxed/offline `nix build` can fail unless those sbt boot artifacts are also available offline (typically by aligning `sbt.version`, or by manually pinning the missing sbt artifacts in `manual-repo.nix`).
@@ -73,7 +73,7 @@ Add an input and expose the sbtix CLI in your dev shell:
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # Prefer a tag (or pinned commit) so the sbtix input is stable.
-    sbtix.url = "github:natural-transformation/sbtix/v1.0.0";
+    sbtix.url = "github:natural-transformation/sbtix/v1.0.1";
 
     # Optional: keep nixpkgs consistent across inputs.
     sbtix.inputs.nixpkgs.follows = "nixpkgs";

--- a/plugin/build.sbt
+++ b/plugin/build.sbt
@@ -2,7 +2,7 @@ sbtPlugin := true
 
 name         := "sbtix"
 organization := "se.nullable.sbtix"
-version      := "1.0.0"
+version      := "1.0.1"
 
 publishTo := {
     if (isSnapshot.value) {

--- a/plugin/src/main/scala/se/nullable/sbtix/CoursierArtifactFetcher.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/CoursierArtifactFetcher.scala
@@ -154,7 +154,7 @@ class CoursierArtifactFetcher(
               s"[SBTIX_DEBUG] Treating ${dependency.module.organization.value}:${dependency.module.name.value}:${dependency.version} as provided from ${artifact.url}"
             }
             (lockedAcc, providedAcc + ProvidedArtifact.from(dependency, artifact.url))
-          } else if (isMutableMavenMetadataUrl(artifact.url)) {
+          } else if (isMavenMetadataUrl(artifact.url)) {
             (lockedAcc, providedAcc)
           } else {
             val expanded = fetchAndExpand(artifact, repoDescriptors, dependency)
@@ -167,7 +167,7 @@ class CoursierArtifactFetcher(
     val metaArtifacts = metaArtifactCollector.asScala.toSet
       .filterNot(meta => resolvedUrls.contains(meta.artifactUrl))
       .filterNot(meta => isLocalIvyUrl(meta.artifactUrl))
-      .filterNot(meta => isMutableMavenMetadataUrl(meta.artifactUrl))
+      .filterNot(meta => isMavenMetadataUrl(meta.artifactUrl))
       .flatMap { meta =>
         val descriptor = descriptorForUrl(meta.artifactUrl, repoDescriptors)
         val relative = computeRelativePath(meta.artifactUrl, descriptor)
@@ -507,7 +507,7 @@ class CoursierArtifactFetcher(
         if (
           res.isRight &&
           artifact.url.startsWith("http") &&
-          !isMutableMavenMetadataUrl(artifact.url)
+          !isMavenMetadataUrl(artifact.url)
         ) {
           val checkSum =
             FindArtifactsOfRepo
@@ -722,14 +722,19 @@ class CoursierArtifactFetcher(
       .getOrElse(Set.empty)
 
   private def shouldLockReportArtifact(url: String): Boolean =
-    !isMutableMavenMetadataUrl(url) && !(url.startsWith("file:") && isLocalIvyUrl(url))
+    !isMavenMetadataUrl(url) && !(url.startsWith("file:") && isLocalIvyUrl(url))
 
-  private def isMutableMavenMetadataUrl(url: String): Boolean = {
+  private def isMavenMetadataUrl(url: String): Boolean = {
     val stripped = stripCredentials(url)
+    def isMetadataPath(path: String): Boolean = {
+      val cleanPath = path.takeWhile(ch => ch != '?' && ch != '#')
+      val fileName = cleanPath.split('/').lastOption.getOrElse("")
+      fileName == "maven-metadata.xml" || fileName.startsWith("maven-metadata.xml.")
+    }
     Try(new URI(stripped)).toOption
       .flatMap(uri => Option(uri.getPath))
-      .exists(_.endsWith("/maven-metadata.xml")) ||
-      stripped.takeWhile(_ != '?').endsWith("/maven-metadata.xml")
+      .exists(isMetadataPath) ||
+      isMetadataPath(stripped)
   }
 
   private def reportPomArtifacts(

--- a/plugin/src/main/scala/se/nullable/sbtix/CoursierArtifactFetcher.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/CoursierArtifactFetcher.scala
@@ -154,6 +154,8 @@ class CoursierArtifactFetcher(
               s"[SBTIX_DEBUG] Treating ${dependency.module.organization.value}:${dependency.module.name.value}:${dependency.version} as provided from ${artifact.url}"
             }
             (lockedAcc, providedAcc + ProvidedArtifact.from(dependency, artifact.url))
+          } else if (isMutableMavenMetadataUrl(artifact.url)) {
+            (lockedAcc, providedAcc)
           } else {
             val expanded = fetchAndExpand(artifact, repoDescriptors, dependency)
             (lockedAcc ++ expanded, providedAcc)
@@ -165,6 +167,7 @@ class CoursierArtifactFetcher(
     val metaArtifacts = metaArtifactCollector.asScala.toSet
       .filterNot(meta => resolvedUrls.contains(meta.artifactUrl))
       .filterNot(meta => isLocalIvyUrl(meta.artifactUrl))
+      .filterNot(meta => isMutableMavenMetadataUrl(meta.artifactUrl))
       .flatMap { meta =>
         val descriptor = descriptorForUrl(meta.artifactUrl, repoDescriptors)
         val relative = computeRelativePath(meta.artifactUrl, descriptor)
@@ -501,7 +504,11 @@ class CoursierArtifactFetcher(
             } else read(f)
           } else notFound(f)
 
-        if (res.isRight && artifact.url.startsWith("http")) {
+        if (
+          res.isRight &&
+          artifact.url.startsWith("http") &&
+          !isMutableMavenMetadataUrl(artifact.url)
+        ) {
           val checkSum =
             FindArtifactsOfRepo
               .fetchChecksum(artifact.url, "-Meta- Artifact", f.toURI.toURL)
@@ -715,7 +722,15 @@ class CoursierArtifactFetcher(
       .getOrElse(Set.empty)
 
   private def shouldLockReportArtifact(url: String): Boolean =
-    !(url.startsWith("file:") && isLocalIvyUrl(url))
+    !isMutableMavenMetadataUrl(url) && !(url.startsWith("file:") && isLocalIvyUrl(url))
+
+  private def isMutableMavenMetadataUrl(url: String): Boolean = {
+    val stripped = stripCredentials(url)
+    Try(new URI(stripped)).toOption
+      .flatMap(uri => Option(uri.getPath))
+      .exists(_.endsWith("/maven-metadata.xml")) ||
+      stripped.takeWhile(_ != '?').endsWith("/maven-metadata.xml")
+  }
 
   private def reportPomArtifacts(
       url: String,

--- a/plugin/src/main/scala/se/nullable/sbtix/NixPlugin.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/NixPlugin.scala
@@ -27,7 +27,7 @@ object NixPlugin extends AutoPlugin {
     sbtixNixFile := new File(baseDirectory.value, "sbtix.nix"),
     nixRepoFile := new File(baseDirectory.value, "repo.nix"),
     nixProjectRepo := new File(new File(baseDirectory.value, "project"), "repo.nix"),
-    sbtixVersion := "1.0.0"
+    sbtixVersion := "1.0.1"
   )
 
   override def globalSettings = Seq(

--- a/plugin/src/test/scala/sbtix/CoursierArtifactFetcherSpec.scala
+++ b/plugin/src/test/scala/sbtix/CoursierArtifactFetcherSpec.scala
@@ -120,7 +120,7 @@ class CoursierArtifactFetcherSpec extends AnyFlatSpec with Matchers {
     )
 
     val (_, artifacts, provided, errors) = fetcher(dependencies)
-    val metadataArtifacts = artifacts.filter(_.relativePath.endsWith("maven-metadata.xml"))
+    val metadataArtifacts = artifacts.filter(_.relativePath.contains("maven-metadata.xml"))
 
     errors.flatMap(_.errors) shouldBe empty
     provided shouldBe empty

--- a/plugin/src/test/scala/sbtix/CoursierArtifactFetcherSpec.scala
+++ b/plugin/src/test/scala/sbtix/CoursierArtifactFetcherSpec.scala
@@ -99,6 +99,36 @@ class CoursierArtifactFetcherSpec extends AnyFlatSpec with Matchers {
     artifacts.exists(_.relativePath.contains("-javadoc.jar")) shouldBe true
   }
 
+  it should "not lock mutable Maven metadata fetched during version-range resolution" in {
+    val resolvers = Set[Resolver](
+      MavenRepository("central", "https://repo1.maven.org/maven2")
+    )
+
+    val dependencies = Set(
+      Dependency(
+        ModuleID("org.agrona", "agrona", "[1.22.0,1.23.1]")
+      )
+    )
+
+    val fetcher = new CoursierArtifactFetcher(
+      mockLogger,
+      resolvers,
+      Set.empty,
+      "2.12.20",
+      "2.12",
+      artifactClassifiers = Seq.empty
+    )
+
+    val (_, artifacts, provided, errors) = fetcher(dependencies)
+    val metadataArtifacts = artifacts.filter(_.relativePath.endsWith("maven-metadata.xml"))
+
+    errors.flatMap(_.errors) shouldBe empty
+    provided shouldBe empty
+    withClue(s"metadata artifacts should not be pinned in repo.nix: $metadataArtifacts") {
+      metadataArtifacts shouldBe empty
+    }
+  }
+
   it should "preserve Ivy resolver patterns for sbt plugin repositories" in {
     val ivyPattern =
       "[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"

--- a/sbtix-tool.nix
+++ b/sbtix-tool.nix
@@ -2,7 +2,7 @@
 , jdk, jre, sbt, selfSourceInfo ? {}
 }:
 let
-  version = "1.0.0";
+  version = "1.0.1";
   versionSnapshotSuffix = "";
   pluginVersion = "${version}${versionSnapshotSuffix}";
 


### PR DESCRIPTION
## Summary
- add a regression test for version-range resolution pinning Maven metadata
- skip maven-metadata.xml and sidecar files when collecting or locking artifacts
- bump sbtix plugin/tool versions to 1.0.1 and align README, CONTRIBUTING, and CHANGELOG for the bugfix release

## Tests
- sbt "Test / testOnly sbtix.CoursierArtifactFetcherSpec -- -z metadata"
- sbt "show version" "Test / test"
- nix eval --raw .#packages.aarch64-darwin.sbtix.name