### PR TITLE
Fix sbt-scalafmt plugin closure locking

### DIFF
--- a/plugin/src/main/scala/se/nullable/sbtix/NixArtifact.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/NixArtifact.scala
@@ -16,7 +16,7 @@ case class NixArtifact(
   url: String,
   sha256: String
 ) {
-  private val entryName = {
+  val entryName: String = {
     val cleanPath = if (relativePath.startsWith("/")) relativePath.drop(1) else relativePath
     s"$repoName/$cleanPath"
   }
@@ -65,4 +65,4 @@ object NixArtifact {
     val artifactId = url.split("/").takeRight(1).head
     NixArtifact("nix-public", artifactId, url, checksum(file))
   }
-} 
+}

--- a/plugin/src/main/scala/se/nullable/sbtix/NixWriter2.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/NixWriter2.scala
@@ -4,6 +4,19 @@ package se.nullable.sbtix
  * A simplified helper for writing Nix expressions
  */
 object NixWriter2 {
+  private def fileName(path: String): String =
+    path.takeWhile(ch => ch != '?' && ch != '#').split('/').lastOption.getOrElse("")
+
+  private def chooseArtifactForKey(artifacts: Seq[NixArtifact]): NixArtifact =
+    artifacts
+      .sortBy { artifact =>
+        val urlFileMatchesPath =
+          fileName(artifact.url) == fileName(artifact.relativePath)
+        // If no URL filename matches the offline path, keep the fallback deterministic.
+        (if (urlFileMatchesPath) 0 else 1, artifact.url, artifact.sha256)
+      }
+      .head
+
   /**
    * Creates a Nix expression for the repository
    */
@@ -40,6 +53,10 @@ object NixWriter2 {
     val sortedArtifacts =
       artifacts.toSeq
         .filterNot(_.url.startsWith("file:"))
+        .groupBy(_.entryName)
+        .values
+        .map(chooseArtifactForKey)
+        .toSeq
         .sortBy(a => (a.repoName, a.relativePath))
     if (sortedArtifacts.nonEmpty) {
       builder.append(sortedArtifacts.map(_.toNix).mkString("\n"))

--- a/plugin/src/main/scala/se/nullable/sbtix/SbtixPlugin.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/SbtixPlugin.scala
@@ -605,7 +605,7 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
     }
   }
 
-  private final case class DependencyFetch(
+  private[sbtix] final case class DependencyFetch(
       dependencies: Set[Dependency],
       artifactClassifiers: Seq[String],
       context: Option[String] = None
@@ -637,10 +637,13 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
       FetchResult.fromLocked(fetcher(Seq.empty[String]).fromUpdateReport(report))
   }
 
-  private sealed trait PluginFetchPlan
-  private case object NoPluginFetch extends PluginFetchPlan
-  private final case class PluginReportFetch(report: UpdateReport) extends PluginFetchPlan
-  private final case class PluginDependencyFetches(fetches: Seq[DependencyFetch]) extends PluginFetchPlan
+  private[sbtix] sealed trait PluginFetchPlan
+  private[sbtix] case object NoPluginFetch extends PluginFetchPlan
+  private[sbtix] final case class PluginReportAndDependencyFetches(
+      report: UpdateReport,
+      fetches: Seq[DependencyFetch]
+  ) extends PluginFetchPlan
+  private[sbtix] final case class PluginDependencyFetches(fetches: Seq[DependencyFetch]) extends PluginFetchPlan
 
   private def nonEmptyFetches(fetches: DependencyFetch*): Seq[DependencyFetch] =
     fetches.filter(_.dependencies.nonEmpty)
@@ -694,21 +697,28 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
       "sbtBinaryVersion" -> sbtBinaryVersion
     )
 
-  private def pluginFetchPlan(
+  private[sbtix] def pluginFetchPlan(
       pluginModuleIds: Set[ModuleID],
       updateReport: Option[UpdateReport],
       artifactClassifiers: Seq[String]
   ): PluginFetchPlan = {
     val (scalafmtPluginModuleIds, regularPluginModuleIds) =
       pluginModuleIds.partition(isSbtScalafmtPlugin)
+    val dependencyFetches =
+      updateReport match {
+        case Some(_) if scalafmtPluginModuleIds.nonEmpty =>
+          pluginDependencyFetchPlan(regularPluginModuleIds, Set.empty, artifactClassifiers)
+        case _ =>
+          pluginDependencyFetchPlan(regularPluginModuleIds, scalafmtPluginModuleIds, artifactClassifiers)
+      }
 
     (pluginModuleIds.isEmpty, scalafmtPluginModuleIds.nonEmpty, updateReport) match {
       case (true, _, _) =>
         NoPluginFetch
       case (_, true, Some(report)) =>
-        PluginReportFetch(report)
+        PluginReportAndDependencyFetches(report, dependencyFetches)
       case _ =>
-        PluginDependencyFetches(pluginDependencyFetchPlan(regularPluginModuleIds, scalafmtPluginModuleIds, artifactClassifiers))
+        PluginDependencyFetches(dependencyFetches)
     }
   }
 
@@ -740,11 +750,12 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
     plan match {
       case NoPluginFetch =>
         FetchResult.empty
-      case PluginReportFetch(report) =>
-        val result = config.lockUpdateReport(report)
+      case PluginReportAndDependencyFetches(report, fetches) =>
+        val result = FetchResult.combine(Seq(config.lockUpdateReport(report), runFetches(fetches, config)))
         SbtixDebug.info(config.log) {
-          s"[SBTIX_DEBUG] Locked sbt plugin artifacts from already-resolved update report because sbt-scalafmt is present"
+          s"[SBTIX_DEBUG] Locked sbt plugin artifacts from already-resolved update report and declared plugin modules because sbt-scalafmt is present"
         }
+        // URL aliases can still map to the same generated Nix key; NixWriter2 owns final write-time deduplication.
         result
       case PluginDependencyFetches(fetches) =>
         runFetches(fetches, config)

--- a/plugin/src/sbt-test/sbtix/scalafmt/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbtix/scalafmt/project/plugins.sbt
@@ -4,5 +4,6 @@ sys.props.get("plugin.version") match {
 }
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 
 resolvers += Resolver.sbtPluginRepo("releases")

--- a/plugin/src/sbt-test/sbtix/scalafmt/test
+++ b/plugin/src/sbt-test/sbtix/scalafmt/test
@@ -4,6 +4,7 @@ $ exists repo.nix
 $ exists project/repo.nix
 $ exec grep -q 'org/scalameta/scalafmt-core_2.13/3.8.3/scalafmt-core_2.13-3.8.3.jar' repo.nix
 $ exec grep -q 'org/scalameta/sbt-scalafmt_2.12_1.0/2.5.6/sbt-scalafmt-2.5.6.pom' project/repo.nix
+$ exec grep -q 'sbt-revolver' project/repo.nix
 > genComposition
 $ exists default.nix
 $ exec rm -rf result

--- a/plugin/src/test/scala/se/nullable/sbtix/NixWriter2Spec.scala
+++ b/plugin/src/test/scala/se/nullable/sbtix/NixWriter2Spec.scala
@@ -1,0 +1,46 @@
+package se.nullable.sbtix
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class NixWriter2Spec extends AnyFlatSpec with Matchers {
+
+  "NixWriter2" should "deduplicate generated artifact keys" in {
+    val relativePath =
+      "com/github/bigwheel/util-backports_2.12/2.1/util-backports-2.1.pom"
+    val crossSuffixedUrl =
+      "https://repo1.maven.org/maven2/com/github/bigwheel/util-backports_2.12/2.1/util-backports_2.12-2.1.pom"
+    val matchingUrl =
+      "https://repo1.maven.org/maven2/com/github/bigwheel/util-backports_2.12/2.1/util-backports-2.1.pom"
+
+    val output = NixWriter2(
+      Set.empty,
+      Set(
+        NixArtifact("nix-public", relativePath, crossSuffixedUrl, "deadbeef"),
+        NixArtifact("nix-public", relativePath, matchingUrl, "feedface")
+      ),
+      "2.12",
+      "1.0"
+    )
+
+    val generatedKey = "\"nix-public/com/github/bigwheel/util-backports_2.12/2.1/util-backports-2.1.pom\" = {"
+    output.linesIterator.count(_.contains(generatedKey)) shouldBe 1
+    output should include(s"""url = "$matchingUrl";""")
+    output should not include crossSuffixedUrl
+  }
+
+  it should "choose a deterministic duplicate artifact when no URL filename matches" in {
+    val output = NixWriter2(
+      Set.empty,
+      Set(
+        NixArtifact("nix-public", "org/example/demo/1.0/demo-1.0.pom", "https://repo.example/b/demo-other.pom", "feedface"),
+        NixArtifact("nix-public", "org/example/demo/1.0/demo-1.0.pom", "https://repo.example/a/demo-cross.pom", "deadbeef")
+      ),
+      "2.12",
+      "1.0"
+    )
+
+    output should include("""url = "https://repo.example/a/demo-cross.pom";""")
+    output should not include "https://repo.example/b/demo-other.pom"
+  }
+}

--- a/plugin/src/test/scala/se/nullable/sbtix/SbtixPluginSpec.scala
+++ b/plugin/src/test/scala/se/nullable/sbtix/SbtixPluginSpec.scala
@@ -1,0 +1,30 @@
+package se.nullable.sbtix
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+import sbt.ModuleID
+import sbt.librarymanagement.UpdateReport
+
+class SbtixPluginSpec extends AnyFlatSpec with Matchers with OptionValues {
+
+  "pluginFetchPlan" should "resolve declared plugin modules when sbt-scalafmt also has an update report" in {
+    val regularPlugin = ModuleID("io.spray", "sbt-revolver", "0.10.0")
+    val scalafmtPlugin = ModuleID("org.scalameta", "sbt-scalafmt", "2.5.6")
+    val report = null.asInstanceOf[UpdateReport]
+
+    val plan = SbtixPlugin.pluginFetchPlan(
+      Set(regularPlugin, scalafmtPlugin),
+      Some(report),
+      Seq("sources", "tests")
+    )
+
+    plan shouldBe a[SbtixPlugin.PluginReportAndDependencyFetches]
+    val SbtixPlugin.PluginReportAndDependencyFetches(`report`, fetches) = plan
+    fetches.map(_.context.getOrElse("")) should contain only "sbtixGenerate (plugin)"
+
+    val regularFetch = fetches.find(_.context.contains("sbtixGenerate (plugin)")).value
+    regularFetch.artifactClassifiers shouldBe Seq("sources", "tests")
+    regularFetch.dependencies.map(_.moduleId) shouldBe Set(regularPlugin)
+  }
+}


### PR DESCRIPTION
## Summary
- keep declared sbt plugin dependency resolution when `sbt-scalafmt` also provides an sbt update report
- combine update-report locking with direct plugin module fetches so non-scalafmt plugin artifacts remain available offline
- add a regression test for mixed regular-plugin + `sbt-scalafmt` fetch planning

## Verification
- `sbt "testOnly se.nullable.sbtix.SbtixPluginSpec"`
- `sbt test`