### PR TITLE
Lock POMs for evicted direct dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run scripted simple test
         run: nix develop . --command bash -lc 'cd plugin && sbt "scripted sbtix/simple"'
 
+      - name: Run scripted evicted direct POM test
+        run: nix develop . --command bash -lc 'cd plugin && sbt "scripted sbtix/evicted-direct-pom"'
+
       - name: Run scripted private auth test
         run: |
           nix develop . --command bash -lc '

--- a/plugin/src/main/scala/se/nullable/sbtix/CoursierArtifactFetcher.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/CoursierArtifactFetcher.scala
@@ -1052,9 +1052,7 @@ class CoursierArtifactFetcher(
       repoDescriptors: Seq[RepoDescriptor],
       fetchIfMissing: Boolean
   ): Set[(String, File)] = {
-    val moduleName = resolveModuleName(module)
-    val modulePath =
-      s"${module.organization.replace('.', '/')}/${moduleName}/${module.revision}/${moduleName}-${module.revision}.pom"
+    val modulePath = modulePomPath(module)
     repoDescriptors.flatMap { descriptor =>
       val url = descriptor.normalizedRoot + modulePath
       cachedFileForUrl(url)
@@ -1062,6 +1060,11 @@ class CoursierArtifactFetcher(
         .orElse(if (fetchIfMissing && descriptor.normalizedRoot == DefaultPublicRoot) downloadArtifact(artifactForUrl(url)) else None)
         .map(file => (url, file))
     }.toSet
+  }
+
+  private[sbtix] def modulePomPath(module: ModuleID): String = {
+    val moduleName = resolveModuleName(module)
+    s"${module.organization.replace('.', '/')}/${moduleName}/${module.revision}/${moduleName}-${module.revision}.pom"
   }
 
   private def pomUrlFromArtifactUrl(module: ModuleID, artifactUrl: String): Option[String] = {

--- a/plugin/src/main/scala/se/nullable/sbtix/CoursierArtifactFetcher.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/CoursierArtifactFetcher.scala
@@ -337,18 +337,18 @@ class CoursierArtifactFetcher(
     (nixRepos, artifacts)
   }
 
-  def lockModulePoms(modules: Set[ModuleID]): (Set[NixRepo], Set[NixArtifact]) = {
+  def lockModulePoms(modules: Set[ModuleID], fetchIfMissing: Boolean = false): (Set[NixRepo], Set[NixArtifact]) = {
     val repoDescriptors = buildRepoDescriptors(effectiveResolvers)
     val nixRepos = repoDescriptors.map(_.repo).toSet
     val artifacts =
       modules.flatMap(publicationVariants).flatMap { module =>
-        modulePomCandidates(module, repoDescriptors, fetchIfMissing = false).flatMap { case (url, file) =>
+        modulePomCandidates(module, repoDescriptors, fetchIfMissing = fetchIfMissing).flatMap { case (url, file) =>
           lockCachedArtifact(url, file, repoDescriptors) ++ collectCachedPomAncestors(file, repoDescriptors)
         }
       }
 
     SbtixDebug.info(logger) {
-      s"[SBTIX_DEBUG] Locked ${artifacts.size} cached module POM artifacts"
+      s"[SBTIX_DEBUG] Locked ${artifacts.size} module POM artifacts"
     }
     (nixRepos, artifacts)
   }
@@ -1052,8 +1052,9 @@ class CoursierArtifactFetcher(
       repoDescriptors: Seq[RepoDescriptor],
       fetchIfMissing: Boolean
   ): Set[(String, File)] = {
+    val moduleName = resolveModuleName(module)
     val modulePath =
-      s"${module.organization.replace('.', '/')}/${module.name}/${module.revision}/${module.name}-${module.revision}.pom"
+      s"${module.organization.replace('.', '/')}/${moduleName}/${module.revision}/${moduleName}-${module.revision}.pom"
     repoDescriptors.flatMap { descriptor =>
       val url = descriptor.normalizedRoot + modulePath
       cachedFileForUrl(url)

--- a/plugin/src/main/scala/se/nullable/sbtix/SbtixPlugin.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/SbtixPlugin.scala
@@ -423,6 +423,30 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
     ModuleID(organization, rawModule, version).withExtraAttributes(attrs)
   }
 
+  private def moduleKeys(module: ModuleID, scalaVersion: String, scalaBinaryVersion: String): Set[(String, String, String)] = {
+    val resolvedName =
+      CrossVersion(module.crossVersion, scalaVersion, scalaBinaryVersion)
+        .map(applyFn => applyFn(module.name))
+        .getOrElse(module.name)
+    Set(module.name, resolvedName).map(name => (module.organization, name, module.revision))
+  }
+
+  private[sbtix] def evictedDeclaredModules(
+      declaredModules: Set[ModuleID],
+      report: UpdateReport,
+      scalaVersion: String,
+      scalaBinaryVersion: String
+  ): Set[ModuleID] = {
+    val evictedKeys =
+      report.configurations
+        .flatMap(_.modules)
+        .filter(_.evicted)
+        .flatMap(moduleReport => moduleKeys(moduleReport.module, scalaVersion, scalaBinaryVersion))
+        .toSet
+
+    declaredModules.filter(module => moduleKeys(module, scalaVersion, scalaBinaryVersion).exists(evictedKeys))
+  }
+
   private def parseSbtPluginLine(line: String, scalaBinary: String, sbtBinary: String): Option[ModuleID] = {
     val trimmed = line.trim
     trimmed match {
@@ -891,6 +915,10 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
           log,
           "sbtixGenerate"
         ).toSet
+      val evictedDeclaredProjectModules =
+        evictedDeclaredModules(declaredProjectModules, projectUpdateReport, scalaVer, scalaBinaryVersion.value)
+      val nonEvictedDeclaredProjectModules =
+        declaredProjectModules -- evictedDeclaredProjectModules
 
       // sbt itself downloads some "tooling" artifacts during compilation, even
       // when they are not declared as normal project/library dependencies. Lock
@@ -903,9 +931,10 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
         FetchResult.combine(
           Seq(
             fetcherConfig.lockUpdateReport(projectUpdateReport, sbtixArtifactClassifiers.value),
+            fetcherConfig.lockModulePoms(nonEvictedDeclaredProjectModules),
             // Declared roots may be evicted from the final classpath, but sbt still
             // resolves their original POMs before applying eviction.
-            fetcherConfig.lockModulePoms(declaredProjectModules, fetchIfMissing = true),
+            fetcherConfig.lockModulePoms(evictedDeclaredProjectModules, fetchIfMissing = true),
             runFetches(
               dependencyFetchPlan(toolingDependencies, scalafmtRuntimeDeps, sbtixArtifactClassifiers.value),
               fetcherConfig

--- a/plugin/src/main/scala/se/nullable/sbtix/SbtixPlugin.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/SbtixPlugin.scala
@@ -654,8 +654,8 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
     def lockUpdateReport(report: UpdateReport, artifactClassifiers: Seq[String]): FetchResult =
       FetchResult.fromLocked(fetcher(artifactClassifiers).fromUpdateReport(report))
 
-    def lockModulePoms(modules: Set[ModuleID]): FetchResult =
-      FetchResult.fromLocked(fetcher(Seq.empty[String]).lockModulePoms(modules))
+    def lockModulePoms(modules: Set[ModuleID], fetchIfMissing: Boolean = false): FetchResult =
+      FetchResult.fromLocked(fetcher(Seq.empty[String]).lockModulePoms(modules, fetchIfMissing))
   }
 
   private[sbtix] sealed trait PluginFetchPlan
@@ -903,7 +903,9 @@ ln -sf ivy.xml $$ivyDir/ivys/ivy-$version.xml"""
         FetchResult.combine(
           Seq(
             fetcherConfig.lockUpdateReport(projectUpdateReport, sbtixArtifactClassifiers.value),
-            fetcherConfig.lockModulePoms(declaredProjectModules),
+            // Declared roots may be evicted from the final classpath, but sbt still
+            // resolves their original POMs before applying eviction.
+            fetcherConfig.lockModulePoms(declaredProjectModules, fetchIfMissing = true),
             runFetches(
               dependencyFetchPlan(toolingDependencies, scalafmtRuntimeDeps, sbtixArtifactClassifiers.value),
               fetcherConfig

--- a/plugin/src/sbt-test/sbtix/evicted-direct-pom/Main.scala
+++ b/plugin/src/sbt-test/sbtix/evicted-direct-pom/Main.scala
@@ -1,0 +1,4 @@
+object Main {
+  def main(args: Array[String]): Unit =
+    println("evicted direct dependency fixture")
+}

--- a/plugin/src/sbt-test/sbtix/evicted-direct-pom/build.sbt
+++ b/plugin/src/sbt-test/sbtix/evicted-direct-pom/build.sbt
@@ -1,0 +1,11 @@
+ThisBuild / scalaVersion := "3.7.4"
+ThisBuild / version := "0.1.0"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "evicted-direct-pom",
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio-json" % "0.7.3",
+      "dev.zio" %% "zio-http" % "3.8.0"
+    )
+  )

--- a/plugin/src/sbt-test/sbtix/evicted-direct-pom/project/build.properties
+++ b/plugin/src/sbt-test/sbtix/evicted-direct-pom/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.11

--- a/plugin/src/sbt-test/sbtix/evicted-direct-pom/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbtix/evicted-direct-pom/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(version) => addSbtPlugin("se.nullable.sbtix" % "sbtix" % version)
+  case _ => sys.error("The system property 'plugin.version' is not defined.")
+}

--- a/plugin/src/sbt-test/sbtix/evicted-direct-pom/test
+++ b/plugin/src/sbt-test/sbtix/evicted-direct-pom/test
@@ -1,0 +1,6 @@
+# Reproduces a vat-saas failure where an older direct dependency is evicted by
+# transitive resolution, but sbt still needs its POM metadata for offline Nix resolution.
+> sbtixGenerate
+$ exists repo.nix
+$ exec grep -q 'dev/zio/zio-json_3/0.7.44/zio-json_3-0.7.44.jar' repo.nix
+$ exec grep -q 'dev/zio/zio-json_3/0.7.3/zio-json_3-0.7.3.pom' repo.nix

--- a/plugin/src/test/scala/se/nullable/sbtix/CoursierArtifactFetcherUnitSpec.scala
+++ b/plugin/src/test/scala/se/nullable/sbtix/CoursierArtifactFetcherUnitSpec.scala
@@ -1,0 +1,26 @@
+package se.nullable.sbtix
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sbt.{CrossVersion, Logger, ModuleID}
+
+class CoursierArtifactFetcherUnitSpec extends AnyFlatSpec with Matchers {
+  private val noopLogger = new Logger {
+    def trace(t: => Throwable): Unit = ()
+    def success(message: => String): Unit = ()
+    def log(level: sbt.Level.Value, message: => String): Unit = ()
+  }
+
+  "modulePomPath" should "use resolved Scala cross-versioned module names" in {
+    val fetcher = new CoursierArtifactFetcher(
+      noopLogger,
+      resolvers = Set.empty,
+      credentials = Set.empty,
+      scalaVersion = "3.7.4",
+      scalaBinaryVersion = "3"
+    )
+    val module = ModuleID("dev.zio", "zio-json", "0.7.3").cross(CrossVersion.binary)
+
+    fetcher.modulePomPath(module) shouldBe "dev/zio/zio-json_3/0.7.3/zio-json_3-0.7.3.pom"
+  }
+}

--- a/plugin/src/test/scala/se/nullable/sbtix/SbtixPluginSpec.scala
+++ b/plugin/src/test/scala/se/nullable/sbtix/SbtixPluginSpec.scala
@@ -3,7 +3,7 @@ package se.nullable.sbtix
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.OptionValues
-import sbt.ModuleID
+import sbt.{CrossVersion, ModuleID}
 import sbt.librarymanagement.{ConfigRef, ConfigurationReport, ModuleReport, UpdateReport, UpdateStats}
 import java.io.File
 import java.nio.file.Files
@@ -106,5 +106,25 @@ class SbtixPluginSpec extends AnyFlatSpec with Matchers with OptionValues {
       innerPlugins.getCanonicalFile,
       outerPlugins.getCanonicalFile
     )
+  }
+
+  "evictedDeclaredModules" should "select only declared roots that are evicted in the update report" in {
+    val evictedDeclared = ModuleID("dev.zio", "zio-json", "0.7.3").cross(CrossVersion.binary)
+    val activeDeclared = ModuleID("dev.zio", "zio", "2.1.23").cross(CrossVersion.binary)
+    val evictedReport = ModuleReport(ModuleID("dev.zio", "zio-json_3", "0.7.3"), Vector.empty, Vector.empty).withEvicted(true)
+    val activeReport = ModuleReport(ModuleID("dev.zio", "zio_3", "2.1.23"), Vector.empty, Vector.empty)
+    val report = UpdateReport(
+      new File("ivy.xml"),
+      Vector(ConfigurationReport(ConfigRef("compile"), Vector(evictedReport, activeReport), Vector.empty)),
+      UpdateStats(0L, 0L, 0L, cached = true),
+      Map.empty
+    )
+
+    SbtixPlugin.evictedDeclaredModules(
+      Set(evictedDeclared, activeDeclared),
+      report,
+      scalaVersion = "3.7.4",
+      scalaBinaryVersion = "3"
+    ) shouldBe Set(evictedDeclared)
   }
 }


### PR DESCRIPTION
## Summary
- Lock original POM metadata for direct project dependencies that are evicted from the final update report.
- Use cross-versioned module names when constructing module POM paths.
- Add unit and scripted regression coverage, and run the new scripted fixture in CI.

## Verification
- `git diff --check master...HEAD`
- `nix develop . --command bash -lc 'cd plugin && sbt "Test / testOnly se.nullable.sbtix.CoursierArtifactFetcherUnitSpec se.nullable.sbtix.SbtixPluginSpec"'`\n- `nix develop . --command bash -lc 'cd plugin && sbt "scripted sbtix/evicted-direct-pom"'`\n- Earlier full sweep before the CI-only follow-up commit: `nix develop . --command bash -lc 'cd plugin && sbt "Test / test"'`; `nix build .#sbtix -L`